### PR TITLE
Fix missremembering that hintpaths stack

### DIFF
--- a/NeosModConfigurationExample/NeosModConfigurationExample.csproj
+++ b/NeosModConfigurationExample/NeosModConfigurationExample.csproj
@@ -20,15 +20,15 @@
 
   <ItemGroup>
     <Reference Include="HarmonyLib">
-      <HintPath>$(NeosPath)0Harmony.dll</HintPath>
       <HintPath>$(NeosPath)nml_libs\0Harmony.dll</HintPath>
+      <HintPath Condition="Exists('$(NeosPath)0Harmony.dll')">$(NeosPath)0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="BaseX">
       <HintPath>$(NeosPath)Neos_Data\Managed\BaseX.dll</HintPath>
     </Reference>
     <Reference Include="NeosModLoader">
-      <HintPath>$(NeosPath)NeosModLoader.dll</HintPath>
       <HintPath>$(NeosPath)Libraries\NeosModLoader.dll</HintPath>
+      <HintPath Condition="Exists('$(NeosPath)NeosModLoader.dll')">$(NeosPath)NeosModLoader.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>$(NeosPath)Neos_Data\Managed\Newtonsoft.Json.dll</HintPath>


### PR DESCRIPTION
I seem to have miss-remembered how msbuild deals with multiple HintPaths. They need an exist condition too, since the HintPath variables seem to just overwrite each other like any other variables.
This PR would fix adding the other reference paths conditionally.